### PR TITLE
Optionally depend on usertiming-compression.

### DIFF
--- a/plugins/usertiming.js
+++ b/plugins/usertiming.js
@@ -112,16 +112,16 @@
 			var utc = window.UserTimingCompression || BOOMR.window.UserTimingCompression;
 
 			if (typeof utc === "undefined") {
-				if (entries.length == 0) {
+				if (entries.length === 0) {
 					return null;
 				} else {
 					var res = {};
 					for (var i = 0, l = entries.length; i < l; i++) {
 						var entry = entries[i];
 						res[entry.entryType] = res[entry.entryType] || {};
-						if (entry.entryType == "mark") {
+						if (entry.entryType === "mark") {
 							res[entry.entryType][entry.name] = entry.startTime;
-						} else if (entry.entryType == "measure") {
+						} else if (entry.entryType === "measure") {
 							res[entry.entryType][entry.name] = entry.duration;
 						}
 					}

--- a/plugins/usertiming.js
+++ b/plugins/usertiming.js
@@ -51,7 +51,7 @@
  *     {"name":"mark2","startTime":200,"duration":0,"entryType":"mark"},
  *     {"name":"measure2","startTime":200,"duration":200,"entryType":"measure"}]
  *
- * Uncompressed measures only send their duration in contrast to comrpressed measures, which also send their startTime.
+ * Uncompressed measures only send their duration in contrast to compressed measures, which also send their startTime.
  *
  * ## Compatibility
  *
@@ -93,33 +93,25 @@
 		options: {"from": 0, "window": BOOMR.window},
 
 		/*
-		 * Gets the user timings, filters out those that have already been sent
+		 * Gets the user timings, filters out those that have already been sent.
 		 * Calls the UserTimingCompression library to get the compressed UserTiming
-		 * data that occurred since the last call
+		 * data that occurred since the last call.
 		 *
 		 * @returns {string} UserTiming data
 		 */
 		getUserTiming: function() {
-			var frame, entries, options;
-
-			options = impl.options || {};
-			frame = options.window || window;
-			entries = this.findUserTimingForFrame(frame);
+			var entries = this.findUserTimingForFrame(impl.options.window);
 
 			// 'from' minimum time
-			if (options.from) {
+			if (impl.options.from) {
 				entries = entries.filter(function(e) {
-					return e.startTime + e.duration >= options.from;
+					return e.startTime + e.duration >= impl.options.from;
 				});
 			}
 
 			var utc = window.UserTimingCompression || BOOMR.window.UserTimingCompression;
 
 			if (typeof utc === "undefined") {
-				var timings, res;
-				timings = utc.compressUserTiming(entries);
-				return utc.compressForUri(timings);
-			} else {
 				if (entries.length == 0) {
 					return null;
 				} else {
@@ -135,6 +127,10 @@
 					}
 					return JSON.stringify(res);
 				}
+			} else {
+				var timings, res;
+				timings = utc.compressUserTiming(entries);
+				return utc.compressForUri(timings);
 			}
 		},
 

--- a/plugins/usertiming.js
+++ b/plugins/usertiming.js
@@ -3,9 +3,9 @@
  * The UserTiming plugin to collect metrics from the W3C
  * [UserTiming]{@link http://www.w3.org/TR/user-timing/} API.
  *
- * This plugin is dependent on the
+ * This plugin can make use of the
  * [UserTimingCompression library]{@link https://github.com/nicjansma/usertiming-compression.js}.
- * `UserTimingCompression` must be loaded before this plugin's `init()` is called.
+ * In order to use compression, `UserTimingCompression` must be loaded before this plugin's `init()` is called.
  *
  * This plugin collects all marks and measures that were added since
  * navigation start or since the last beacon fired for the current navigation.
@@ -16,9 +16,9 @@
  *
  * This plugin adds the following parameters to the beacon:
  *
- * * `usertiming`: Compressed ResourceTiming data
+ * * `usertiming`: UserTiming data
  *
- * The value is a compressed string using
+ * The value is either plain json or a compressed string using
  * [UserTimingCompression library]{@link https://github.com/nicjansma/usertiming-compression.js}.
  * A decompression function is also available in the library.
  *
@@ -35,7 +35,11 @@
  *     //measure2 will be the delta between the mark2 timestamp and the current time
  *     performance.measure('measure2', 'mark2');
  *
- * The compressed data added to the beacon will look similar to the following:
+ * When not using compression, data added to the beacon will look similar to the following:
+ *
+ *     usertiming={"mark":{"mark1":100,"mark2":200},"measure":{"measure1":100,"measure2":200}}
+ *
+ * When using compression, data added to the beacon will look similar to the following:
  *
  *     usertiming=~(m~(ark~(1~'2s~2~'5k)~easure~(1~'2s_2s~2~'5k_5k)))
  *
@@ -46,6 +50,8 @@
  *     {"name":"measure1","startTime":100,"duration":100,"entryType":"measure"},
  *     {"name":"mark2","startTime":200,"duration":0,"entryType":"mark"},
  *     {"name":"measure2","startTime":200,"duration":200,"entryType":"measure"}]
+ *
+ * Uncompressed measures only send their duration in contrast to comrpressed measures, which also send their startTime.
  *
  * ## Compatibility
  *
@@ -87,21 +93,49 @@
 		options: {"from": 0, "window": BOOMR.window},
 
 		/*
+		 * Gets the user timings, filters out those that have already been sent
 		 * Calls the UserTimingCompression library to get the compressed UserTiming
-		 * data that occurred since the last call.
+		 * data that occurred since the last call
 		 *
-		 * @returns {string} Compressed UserTiming data
+		 * @returns {string} UserTiming data
 		 */
 		getUserTiming: function() {
-			var timings, res,
-			    now = BOOMR.hrNow(),  // Get a timestamp to compare with performance marks and measures.
-			    utc = window.UserTimingCompression || BOOMR.window.UserTimingCompression;
+			var frame, entries, options;
 
-			timings = utc.getCompressedUserTiming(impl.options);
-			res = utc.compressForUri(timings);
-			this.options.from = now;
+			options = impl.options || {};
+			frame = options.window || window;
+			entries = this.findUserTimingForFrame(frame);
 
-			return res;
+			// 'from' minimum time
+			if (options.from) {
+				entries = entries.filter(function(e) {
+					return e.startTime + e.duration >= options.from;
+				});
+			}
+
+			var utc = window.UserTimingCompression || BOOMR.window.UserTimingCompression;
+
+			if (typeof utc === "undefined") {
+				var timings, res;
+				timings = utc.compressUserTiming(entries);
+				return utc.compressForUri(timings);
+			} else {
+				if (entries.length == 0) {
+					return null;
+				} else {
+					var res = {};
+					for (var i = 0, l = entries.length; i < l; i++) {
+						var entry = entries[i];
+						res[entry.entryType] = res[entry.entryType] || {};
+						if (entry.entryType == "mark") {
+							res[entry.entryType][entry.name] = entry.startTime;
+						} else if (entry.entryType == "measure") {
+							res[entry.entryType][entry.name] = entry.duration;
+						}
+					}
+					return JSON.stringify(res);
+				}
+			}
 		},
 
 		/**
@@ -110,7 +144,7 @@
 		 * Adds the `usertiming` param to the beacon.
 		 */
 		addEntriesToBeacon: function() {
-			var r;
+			var r, now = BOOMR.hrNow();
 
 			if (this.complete) {
 				return;
@@ -124,7 +158,50 @@
 				});
 			}
 
+			this.options.from = now;
+
 			this.complete = true;
+		},
+
+		/**
+		 * Gets all of the UserTiming entries for a frame
+
+		 * @param {object} frame Window or frame DOM object
+		 *
+		 * @returns {PerformanceEntry[]} UserTiming entries
+		 */
+		findUserTimingForFrame: function(frame) {
+			var entries;
+
+			if (!frame) {
+				return [];
+			}
+
+			try {
+				// Try to access location.href first to trigger any Cross-Origin
+				// warnings.  There's also a bug in Chrome ~48 that might cause
+				// the browser to crash if accessing X-O frame.performance.
+				// https://code.google.com/p/chromium/issues/detail?id=585871
+				// This variable is not otherwise used.
+				/* eslint-disable no-unused-vars */
+				var frameLoc = frame.location && frame.location.href;
+				/* eslint-enable no-unused-vars */
+
+				if (!("performance" in frame) ||
+					!frame.performance ||
+					!frame.performance.getEntriesByType) {
+					return entries;
+				}
+
+				// gather marks and measures for this frame
+				// TODO do we need to offset startTime?
+				entries = frame.performance.getEntriesByType("mark");
+				entries = entries.concat(frame.performance.getEntriesByType("measure"));
+			} catch (e) {
+				return entries;
+			}
+
+			return entries;
 		},
 
 		/**
@@ -169,13 +246,6 @@
 		checkSupport: function() {
 			if (this.supported) {
 				return true;
-			}
-
-			// Check that the required UserTimingCompression library is available
-			var utc = window.UserTimingCompression || BOOMR.window.UserTimingCompression;
-			if (typeof utc === "undefined") {
-				BOOMR.warn("UserTimingCompression library not found", "usertiming");
-				return false;
 			}
 
 			var p = BOOMR.getPerformance();

--- a/tests/page-templates/18-usertiming/00-usertiming-none.js
+++ b/tests/page-templates/18-usertiming/00-usertiming-none.js
@@ -1,7 +1,7 @@
 /*eslint-env mocha*/
 /*global BOOMR_test,assert*/
 
-describe("e2e/17-usertiming/00-usertiming-none", function() {
+describe("e2e/18-usertiming/00-usertiming-none", function() {
 	var t = BOOMR_test;
 	var tf = BOOMR.plugins.TestFramework;
 

--- a/tests/page-templates/18-usertiming/01-usertiming-basic.js
+++ b/tests/page-templates/18-usertiming/01-usertiming-basic.js
@@ -1,7 +1,7 @@
 /*eslint-env mocha*/
 /*global BOOMR_test,assert*/
 
-describe("e2e/17-usertiming/01-usertiming-basic", function() {
+describe("e2e/18-usertiming/01-usertiming-basic", function() {
 	var t = BOOMR_test;
 	var tf = BOOMR.plugins.TestFramework;
 

--- a/tests/page-templates/18-usertiming/02-usertiming-polyfill.js
+++ b/tests/page-templates/18-usertiming/02-usertiming-polyfill.js
@@ -2,7 +2,7 @@
 /*eslint-env mocha*/
 /*global assert*/
 
-describe("e2e/17-usertiming/02-usertiming-polyfill", function() {
+describe("e2e/18-usertiming/02-usertiming-polyfill", function() {
 	var tf = BOOMR.plugins.TestFramework;
 	var t = BOOMR_test;
 

--- a/tests/page-templates/18-usertiming/03-usertiming-disabled.js
+++ b/tests/page-templates/18-usertiming/03-usertiming-disabled.js
@@ -1,7 +1,7 @@
 /*eslint-env mocha*/
 /*global BOOMR_test,assert*/
 
-describe("e2e/17-usertiming/03-usertiming-disabled", function() {
+describe("e2e/18-usertiming/03-usertiming-disabled", function() {
 	var t = BOOMR_test;
 	var tf = BOOMR.plugins.TestFramework;
 

--- a/tests/page-templates/18-usertiming/04-usertiming-second-beacon.js
+++ b/tests/page-templates/18-usertiming/04-usertiming-second-beacon.js
@@ -1,7 +1,7 @@
 /*eslint-env mocha*/
 /*global BOOMR_test,assert*/
 
-describe("e2e/17-usertiming/04-usertiming-second-beacon", function() {
+describe("e2e/18-usertiming/04-usertiming-second-beacon", function() {
 	var t = BOOMR_test;
 	var tf = BOOMR.plugins.TestFramework;
 

--- a/tests/page-templates/18-usertiming/05-usertiming-second-beacon-no-performance-now.js
+++ b/tests/page-templates/18-usertiming/05-usertiming-second-beacon-no-performance-now.js
@@ -1,7 +1,7 @@
 /*eslint-env mocha*/
 /*global BOOMR_test,assert*/
 
-describe("e2e/17-usertiming/05-usertiming-second-beacon-no-performance-now", function() {
+describe("e2e/18-usertiming/05-usertiming-second-beacon-no-performance-now", function() {
 	var t = BOOMR_test;
 	var tf = BOOMR.plugins.TestFramework;
 

--- a/tests/page-templates/18-usertiming/06-usertiming-no-compression.html
+++ b/tests/page-templates/18-usertiming/06-usertiming-no-compression.html
@@ -1,0 +1,26 @@
+<%= header %>
+<%= boomerangScript %>
+<script>
+delete window.UserTimingCompression;
+</script>
+<script src="06-usertiming-no-compression.js" type="text/javascript"></script>
+<script>
+if (BOOMR_test.isUserTimingSupported()) {
+	window.performance.mark("mark1");
+	setTimeout(function() {
+		window.performance.mark("mark2");
+		window.performance.measure("measure1", "mark1", "mark2");
+	}, 500);
+}
+</script>
+<script>
+setTimeout(function() {
+	BOOMR_test.init({
+		testAfterOnBeacon: true,
+		UserTiming: {
+			enabled: true
+		}
+	});
+}, 1000);
+</script>
+<%= footer %>

--- a/tests/page-templates/18-usertiming/06-usertiming-no-compression.js
+++ b/tests/page-templates/18-usertiming/06-usertiming-no-compression.js
@@ -1,0 +1,26 @@
+/*eslint-env mocha*/
+/*global BOOMR_test,assert*/
+
+describe("e2e/18-usertiming/06-usertiming-no-compression", function() {
+	var t = BOOMR_test;
+	var tf = BOOMR.plugins.TestFramework;
+
+	it("Should pass basic beacon validation", function(done) {
+		t.validateBeaconWasSent(done);
+	});
+
+	it("Should have usertiming (if UserTiming is supported)", function() {
+		if (t.isUserTimingSupported()) {
+			var b = tf.beacons[0];
+			assert.isString(b.usertiming);
+			var data = JSON.parse(b.usertiming);
+			assert.isTrue("mark" in data);
+			var marks = data.mark
+			assert.isTrue("mark1" in marks);
+			assert.isTrue("mark2" in marks);
+			assert.isTrue("measure" in data);
+			var measures = data.measure;
+			assert.isTrue("measure1" in measures);
+		}
+	});
+});


### PR DESCRIPTION
Make compression optional by adding a configuration option
"ut_compression". When set to falsy, the usertiming plugin does not depend on
the usertiming-compression library, but sends the timings uncompressed
instead.

format for uncompressed send is json, example:

  {"mark":{"foo":1234},{"measure":{"bar":5678,"baz":432}}