### PR TITLE
Navigation Timing: Plugin sends twice per page

### DIFF
--- a/plugins/navtiming.js
+++ b/plugins/navtiming.js
@@ -393,8 +393,8 @@
 					/* empty */
 				}
 
-				if (data["nt_load_end"] > 0) {
-				    this.fullySent = true
+				if (data.nt_load_end > 0) {
+					this.fullySent = true;
 				}
 			}
 

--- a/plugins/navtiming.js
+++ b/plugins/navtiming.js
@@ -114,6 +114,7 @@
 	// A private object to encapsulate all your implementation details
 	var impl = {
 		complete: false,
+		fullySent: false,
 		sendBeacon: function() {
 			this.complete = true;
 			BOOMR.sendBeacon();
@@ -391,6 +392,10 @@
 				catch (ignore) {
 					/* empty */
 				}
+
+				if (data["nt_load_end"] > 0) {
+				    this.fullySent = true
+				}
 			}
 
 			impl.sendBeacon();
@@ -401,7 +406,8 @@
 				BOOMR.removeVar(impl.addedVars);
 				impl.addedVars = [];
 			}
-			this.complete = false;
+			// if we ever sent the full data, we're complete for all times
+			this.complete = this.fullySent;
 		},
 
 		prerenderToVisible: function() {

--- a/tests/page-templates/19-navtiming/04-no-resend-after-complete.html
+++ b/tests/page-templates/19-navtiming/04-no-resend-after-complete.html
@@ -1,0 +1,30 @@
+<%= header %>
+<%= boomerangScript %>
+<script>
+// RT suppresses BOOMR.sendBeacon after pageready beacon
+delete BOOMR.plugins.RT;
+// Continuity suppresses BOOMR.sendBeacon on domcontentloaded beacon
+delete BOOMR.plugins.Continuity;
+
+document.addEventListener("DOMContentLoaded", function(event) {
+    BOOMR.sendBeacon();
+});
+
+// BOOMR sends a beacon itself on pageready...
+
+window.onload = function() {
+
+    window.setTimeout(function() {
+	    BOOMR.sendBeacon();
+	}, 1000);
+};
+
+</script>
+
+<script src="04-no-resend-after-complete.js" type="text/javascript"></script>
+<script>
+BOOMR_test.init({
+	testAfterOnBeacon: 3
+});
+</script>
+<%= footer %>

--- a/tests/page-templates/19-navtiming/04-no-resend-after-complete.html
+++ b/tests/page-templates/19-navtiming/04-no-resend-after-complete.html
@@ -7,15 +7,14 @@ delete BOOMR.plugins.RT;
 delete BOOMR.plugins.Continuity;
 
 document.addEventListener("DOMContentLoaded", function(event) {
-    BOOMR.sendBeacon();
+	BOOMR.sendBeacon();
 });
 
 // BOOMR sends a beacon itself on pageready...
 
 window.onload = function() {
-
-    window.setTimeout(function() {
-	    BOOMR.sendBeacon();
+	window.setTimeout(function() {
+		BOOMR.sendBeacon();
 	}, 1000);
 };
 

--- a/tests/page-templates/19-navtiming/04-no-resend-after-complete.js
+++ b/tests/page-templates/19-navtiming/04-no-resend-after-complete.js
@@ -1,0 +1,18 @@
+/*eslint-env mocha*/
+/*global BOOMR_test,assert*/
+
+describe("e2e/19-navtiming/04-no-resend-after-complete", function() {
+	var tf = BOOMR.plugins.TestFramework;
+	var t = BOOMR_test;
+
+	it("Should only send navigation timing information on second beacon (if NavigationTiming is supported)", function() {
+//		if (t.isNavigationTimingSupported()) {
+			var b1 = tf.beacons[0];
+			assert.isFalse("nt_load_end" in b1)
+			var b2 = tf.beacons[1];
+			assert.isTrue("nt_load_end" in b2)
+			var b3 = tf.beacons[2];
+			assert.isFalse("nt_load_end" in b3)
+//		}
+	});
+});

--- a/tests/page-templates/19-navtiming/04-no-resend-after-complete.js
+++ b/tests/page-templates/19-navtiming/04-no-resend-after-complete.js
@@ -6,13 +6,11 @@ describe("e2e/19-navtiming/04-no-resend-after-complete", function() {
 	var t = BOOMR_test;
 
 	it("Should only send navigation timing information on second beacon (if NavigationTiming is supported)", function() {
-//		if (t.isNavigationTimingSupported()) {
-			var b1 = tf.beacons[0];
-			assert.isFalse("nt_load_end" in b1)
-			var b2 = tf.beacons[1];
-			assert.isTrue("nt_load_end" in b2)
-			var b3 = tf.beacons[2];
-			assert.isFalse("nt_load_end" in b3)
-//		}
+		var b1 = tf.beacons[0];
+		assert.isFalse("nt_load_end" in b1);
+		var b2 = tf.beacons[1];
+		assert.isTrue("nt_load_end" in b2);
+		var b3 = tf.beacons[2];
+		assert.isFalse("nt_load_end" in b3);
 	});
 });


### PR DESCRIPTION
only reset this.complete in clear if loadEventEnd is zero, which means
data was not fully sent in the last beacon.