### PR TITLE
add exception throwing code path to try-catch block.

### DIFF
--- a/boomerang.js
+++ b/boomerang.js
@@ -871,17 +871,17 @@ BOOMR_check_doc_domain();
 			var name = impl.LOCAL_STORAGE_PREFIX + "clss";
 			impl.localStorageSupported = false;
 
-			// we need JSON and localStorage support
-			if (!w.JSON || !w.localStorage) {
-				return;
-			}
-
 			// Browsers with cookies disabled or in private/incognito mode may throw an
 			// error when accessing the localStorage variable
 			try {
-				w.localStorage.setItem(name, name);
-				impl.localStorageSupported = (w.localStorage.getItem(name) === name);
-				w.localStorage.removeItem(name);
+				// we need JSON and localStorage support
+				// Safari with privacy setting "cookies and other website data" enabled triggers an exception on
+				// referencing localStorage, so do it in a try-catch block.
+				if (w.JSON && w.localStorage) {
+					w.localStorage.setItem(name, name);
+					impl.localStorageSupported = (w.localStorage.getItem(name) === name);
+					w.localStorage.removeItem(name);
+				}
 			}
 			catch (ignore) {
 				impl.localStorageSupported = false;


### PR DESCRIPTION
Safari with privacy setting "cookies and other website data" enabled triggers an exception on referencing localStorage, so do it inside of the try-catch block.