### PR TITLE
Fix getBeaconURL error using auto-xhr plugin

### DIFF
--- a/plugins/auto-xhr.js
+++ b/plugins/auto-xhr.js
@@ -375,7 +375,7 @@
 			}
 
 			// don't track our own beacons
-			if (anchor.href.indexOf(BOOMR.getBeaconURL()) === 0) {
+			if (typeof BOOMR.getBeaconURL === "function" && BOOMR.getBeaconURL() && anchor.href.indexOf(BOOMR.getBeaconURL()) === 0) {
 				return true;
 			}
 		}


### PR DESCRIPTION
While using the auto-xhr plugin, I have the following error: 

```
getBeaconURL is not a function
```

It seems that getBeaconURL is not defined. 