### PR TITLE
Fix issue related to screen orientation in iPhone and iPad

### DIFF
--- a/plugins/continuity.js
+++ b/plugins/continuity.js
@@ -3328,9 +3328,11 @@
 			// update the timeline
 			t.increment("orn");
 
+      var orientation = screen.msOrientation || (screen.orientation || screen.mozOrientation || {});
+
 			// add to the log (don't track the actual keys)
 			t.log(LOG_TYPE_ORIENTATION, now, {
-				a: screen.orientation.angle
+				a: orientation.angle
 			});
 
 			// update the interaction monitor


### PR DESCRIPTION
Using the `continuity` plugin, I am seeing the following error in iPad and iPhone user agents. 

`TypeError: undefined is not an object (evaluating 'screen.orientation.angle')`

This PR should address the error. It should fix #214.