### PR TITLE
Boomerang: Optionally send XHR with credentials

### DIFF
--- a/boomerang.js
+++ b/boomerang.js
@@ -361,6 +361,14 @@ BOOMR_check_doc_domain();
 		// disables use of the browser sendBeacon() API.
 		beacon_auth_token: undefined,
 
+		// Sends beacons with Credentials (applies to XHR beacons, not IMG or `sendBeacon()`).
+		// If you need this, you may want to enable `beacon_disable_sendbeacon` as
+		// `sendBeacon()` does not support credentials.
+		beacon_with_credentials: false,
+
+		// Disables navigator.sendBeacon() support
+		beacon_disable_sendbeacon: false,
+
 		// Strip out everything except last two parts of hostname.
 		// This doesn't work well for domains that end with a country tld,
 		// but we allow the developer to override site_domain for that.
@@ -2063,6 +2071,8 @@ BOOMR_check_doc_domain();
 		 * need to call {@link BOOMR.page_ready} yourself.
 		 * @param {string} config.beacon_auth_key Beacon authorization key value
 		 * @param {string} config.beacon_auth_token Beacon authorization token.
+		 * @param {boolean} config.beacon_with_credentials Sends beacon with credentials
+		 * @param {boolean} config.beacon_disable_sendbeacon Disables `navigator.sendBeacon()` support
 		 * @param {string} config.beacon_url The URL to beacon results back to.
 		 * If not set, no beacon will be sent.
 		 * @param {boolean} config.beacon_url_force_https Forces protocol-relative Beacon URLs to HTTPS
@@ -2093,6 +2103,8 @@ BOOMR_check_doc_domain();
 				    "autorun",
 				    "beacon_auth_key",
 				    "beacon_auth_token",
+				    "beacon_with_credentials",
+				    "beacon_disable_sendbeacon",
 				    "beacon_url",
 				    "beacon_url_force_https",
 				    "beacon_type",
@@ -3451,7 +3463,8 @@ BOOMR_check_doc_domain();
 			    // As per W3C, The sendBeacon method does not provide ability to pass any
 			    // header other than 'Content-Type'. So if we need to send data with
 			    // 'Authorization' header, we need to fallback to good old xhr.
-			    typeof impl.beacon_auth_token === "undefined") {
+			    typeof impl.beacon_auth_token === "undefined" &&
+			    !impl.beacon_disable_sendbeacon) {
 				// note we're using sendBeacon with &sb=1
 				var blobData = new w.Blob([paramsJoined + "&sb=1"], {
 					type: "application/x-www-form-urlencoded"
@@ -3536,6 +3549,10 @@ BOOMR_check_doc_domain();
 				}
 
 				xhr.setRequestHeader(impl.beacon_auth_key, impl.beacon_auth_token);
+			}
+
+			if (impl.beacon_with_credentials) {
+				xhr.withCredentials = true;
 			}
 
 			xhr.send(paramsJoined);


### PR DESCRIPTION
Adds `beacon_with_credentials` to enable `xhr.withCredentials` and `beacon_disable_sendbeacon` to disable `sendBeacon()` support.