### PR TITLE
JSDoc: Clarify SPA plugin load-order requirements

### DIFF
--- a/plugins/angular.js
+++ b/plugins/angular.js
@@ -3,8 +3,8 @@
  * App (SPA) navigations for [AngularJS 1.x]{@link https://angularjs.org/}
  * websites.
  *
- * **Note**: This plugins requires the {@link BOOMR.plugins.SPA} and
- * {@link BOOMR.plugins.AutoXHR} plugins.
+ * **Note**: This plugin requires the {@link BOOMR.plugins.AutoXHR} and
+ * {@link BOOMR.plugins.SPA} plugins to be loaded first (in that order).
  *
  * For details on how Boomerang Single Page App instrumentation works, see the
  * {@link BOOMR.plugins.SPA} documentation.

--- a/plugins/backbone.js
+++ b/plugins/backbone.js
@@ -3,8 +3,8 @@
  * App (SPA) navigations for [Backbone.js]{@link https://backbonejs.org/}
  * websites.
  *
- * **Note**: This plugins requires the {@link BOOMR.plugins.SPA} and
- * {@link BOOMR.plugins.AutoXHR} plugins.
+ * **Note**: This plugin requires the {@link BOOMR.plugins.AutoXHR} and
+ * {@link BOOMR.plugins.SPA} plugins to be loaded first (in that order).
  *
  * For details on how Boomerang Single Page App instrumentation works, see the
  * {@link BOOMR.plugins.SPA} documentation.

--- a/plugins/ember.js
+++ b/plugins/ember.js
@@ -3,8 +3,8 @@
  * App (SPA) navigations for [Ember.js]{@link https://www.emberjs.com/}
  * websites.
  *
- * **Note**: This plugins requires the {@link BOOMR.plugins.SPA} and
- * {@link BOOMR.plugins.AutoXHR} plugins.
+ * **Note**: This plugin requires the {@link BOOMR.plugins.AutoXHR} and
+ * {@link BOOMR.plugins.SPA} plugins to be loaded first (in that order).
  *
  * For details on how Boomerang Single Page App instrumentation works, see the
  * {@link BOOMR.plugins.SPA} documentation.

--- a/plugins/history.js
+++ b/plugins/history.js
@@ -11,8 +11,8 @@
  *
  * The History plugin should be used for React apps.
  *
- * **Note**: This plugins requires the {@link BOOMR.plugins.SPA} and
- * {@link BOOMR.plugins.AutoXHR} plugin as well.
+ * **Note**: This plugin requires the {@link BOOMR.plugins.AutoXHR} and
+ * {@link BOOMR.plugins.SPA} plugins to be loaded first (in that order).
  *
  * For details on how Boomerang Single Page App instrumentation works, see the
  * {@link BOOMR.plugins.SPA} documentation.

--- a/plugins/spa.js
+++ b/plugins/spa.js
@@ -2,7 +2,7 @@
  * Enables Single Page App (SPA) performance monitoring.
  *
  * **Note**: The `SPA` plugin requires the {@link BOOMR.plugins.AutoXHR} plugin
- * and one of the following SPA plugins to work:
+ * to be loaded before `SPA`, and one of the following SPA plugins to work:
  *
  * * {@link BOOMR.plugins.Angular}
  * * {@link BOOMR.plugins.Backbone}


### PR DESCRIPTION
Clarifies the order that SPA plugins should be loaded.

https://github.com/akamai/boomerang/issues/209