### PR TITLE
Add support for background image detection for c.tti.hi

### DIFF
--- a/plugins/continuity.js
+++ b/plugins/continuity.js
@@ -1392,6 +1392,17 @@
 						elements[i].src ||
 						(typeof elements[i].getAttribute === "function" && elements[i].getAttribute("xlink:href"));
 
+					// if src if not defined, look for it in css background image
+					if (!src) {
+						if (typeof BOOMR.window.getComputedStyle === "function") {
+							var bgStyle = BOOMR.window.getComputedStyle(elements[i]).getPropertyValue('background');
+							var bgImgUrl = bgStyle.match(/url\(["']?([^"']*)["']?\)/)
+							if (bgImgUrl && bgImgUrl.length > 0) {
+								src = bgImgUrl[1];
+							}
+						}
+					}
+
 					if (src) {
 						entries = p.getEntriesByName(src);
 						if (entries && entries.length) {

--- a/plugins/continuity.js
+++ b/plugins/continuity.js
@@ -1395,10 +1395,13 @@
 					// if src if not defined, look for it in css background image
 					if (!src) {
 						if (typeof BOOMR.window.getComputedStyle === "function") {
-							var bgStyle = BOOMR.window.getComputedStyle(elements[i]).getPropertyValue('background');
-							var bgImgUrl = bgStyle.match(/url\(["']?([^"']*)["']?\)/)
-							if (bgImgUrl && bgImgUrl.length > 0) {
-								src = bgImgUrl[1];
+							var bgStyle = BOOMR.window.getComputedStyle(elements[i]) &&
+								BOOMR.window.getComputedStyle(elements[i]).getPropertyValue("background");
+							if (bgStyle) {
+								var bgImgUrl = bgStyle.match(/url\(["']?([^"']*)["']?\)/);
+								if (bgImgUrl && bgImgUrl.length > 0) {
+									src = bgImgUrl[1];
+								}
 							}
 						}
 					}

--- a/tests/page-templates/21-continuity/17-tti-hero-images.html
+++ b/tests/page-templates/21-continuity/17-tti-hero-images.html
@@ -8,7 +8,6 @@
 <img src="/delay?delay=2000&amp;file=assets/img.jpg" class="hero-image" onload="lastHeroImageLoad()"/>
 <img src="/delay?delay=3000&amp;file=assets/img.jpg" />
 <img src="/delay?delay=5000&amp;file=assets/img.jpg" />
-<div style="background-image: url(/delay?delay=1000&amp;file=assets/img.jpg)"></div>
 <script src="17-tti-hero-images.js" type="text/javascript"></script>
 <script>
 function lastHeroImageLoad() {

--- a/tests/page-templates/21-continuity/17-tti-hero-images.html
+++ b/tests/page-templates/21-continuity/17-tti-hero-images.html
@@ -8,6 +8,7 @@
 <img src="/delay?delay=2000&amp;file=assets/img.jpg" class="hero-image" onload="lastHeroImageLoad()"/>
 <img src="/delay?delay=3000&amp;file=assets/img.jpg" />
 <img src="/delay?delay=5000&amp;file=assets/img.jpg" />
+<div style="background-image: url(/delay?delay=1000&amp;file=assets/img.jpg)"></div>
 <script src="17-tti-hero-images.js" type="text/javascript"></script>
 <script>
 function lastHeroImageLoad() {

--- a/tests/page-templates/21-continuity/33-tti-hero-images-bg-image.html
+++ b/tests/page-templates/21-continuity/33-tti-hero-images-bg-image.html
@@ -1,0 +1,35 @@
+<%= header %>
+<%= continuitySnippet %>
+<%= boomerangScript %>
+<!-- trigger First Paint -->
+<h1>33-tti-hero-images-bg-image</h1>
+<!-- before this delayed image -->
+<div style="background-image: url(/delay?delay=1000&amp;file=assets/img.jpg); height: 600px;" class="hero-image"></div>
+<div style="height: 600px; background: url(/delay?delay=2000&amp;file=assets/img.jpg);" class="hero-image"></div>
+<div style="background-image: url(/delay?delay=3000&amp;file=assets/img.jpg); height: 600px;"></div>
+<div style="background-image: url(/delay?delay=5000&amp;file=assets/img.jpg); height: 600px;"></div>
+<script src="33-tti-hero-images-bg-image.js" type="text/javascript"></script>
+<script>
+var img = new Image ();
+img.onload = function () {
+	OnImageLoaded(this);
+};
+img.src = '/delay?delay=2000&file=assets/img.jpg';
+
+function OnImageLoaded (img) {
+	window.heroImagesLoaded = BOOMR.now();
+	// do another 500ms of work
+	BOOMR_test.busy(500);
+	// time to interactive should be around this timestamp
+	window.timeToInteractive = BOOMR.now();
+}
+
+BOOMR_test.init({
+	testAfterOnBeacon: true,
+	Continuity: {
+		enabled: true,
+		ttiWaitForHeroImages: ".hero-image"
+	}
+});
+</script>
+<%= footer %>

--- a/tests/page-templates/21-continuity/33-tti-hero-images-bg-image.html
+++ b/tests/page-templates/21-continuity/33-tti-hero-images-bg-image.html
@@ -10,19 +10,20 @@
 <div style="background-image: url(/delay?delay=5000&amp;file=assets/img.jpg); height: 600px;"></div>
 <script src="33-tti-hero-images-bg-image.js" type="text/javascript"></script>
 <script>
-var img = new Image ();
-img.onload = function () {
-	OnImageLoaded(this);
-};
-img.src = '/delay?delay=2000&file=assets/img.jpg';
 
-function OnImageLoaded (img) {
+function OnImageLoaded(img) {
 	window.heroImagesLoaded = BOOMR.now();
 	// do another 500ms of work
 	BOOMR_test.busy(500);
 	// time to interactive should be around this timestamp
 	window.timeToInteractive = BOOMR.now();
 }
+
+var img = new Image();
+img.onload = function() {
+	OnImageLoaded(this);
+};
+img.src = "/delay?delay=2000&file=assets/img.jpg";
 
 BOOMR_test.init({
 	testAfterOnBeacon: true,

--- a/tests/page-templates/21-continuity/33-tti-hero-images-bg-image.js
+++ b/tests/page-templates/21-continuity/33-tti-hero-images-bg-image.js
@@ -1,0 +1,48 @@
+/*eslint-env mocha*/
+/*global BOOMR_test,assert*/
+
+describe("e2e/21-continuity/33-tti-hero-images-bg-image", function() {
+	var tf = BOOMR.plugins.TestFramework;
+	var t = BOOMR_test;
+
+	it("Should have sent a single beacon validation", function(done) {
+		t.validateBeaconWasSent(done);
+	});
+
+	it("Should have set the Visually Ready to when the last Hero Image was loaded (c.tti.vr) (if ResourceTiming is supported)", function() {
+		if (t.isResourceTimingSupported()) {
+			var b = tf.lastBeacon();
+
+			var vr = window.heroImagesLoaded;
+
+			var st = parseInt(b["rt.tstart"], 10);
+
+			assert.isDefined(b["c.tti.vr"]);
+			assert.closeTo(parseInt(b["c.tti.vr"], 10), vr - st, 20);
+		}
+	});
+
+	it("Should have set the Time to Interactive (c.tti)", function() {
+		var b = tf.lastBeacon();
+
+		if (t.isNavigationTimingSupported()) {
+			var workDoneTs = window.timeToInteractive - performance.timing.navigationStart;
+
+			assert.isDefined(b["c.tti"]);
+			assert.closeTo(parseInt(b["c.tti"], 10), workDoneTs, 100);
+		}
+	});
+
+	it("Should have set the Time to Hero Images (c.tti.hi)", function() {
+		if (t.isResourceTimingSupported()) {
+			var b = tf.lastBeacon();
+
+			var vr = window.heroImagesLoaded;
+
+			var st = parseInt(b["rt.tstart"], 10);
+
+			assert.isDefined(b["c.tti.hi"]);
+			assert.closeTo(parseInt(b["c.tti.hi"], 10), vr - st, 20);
+		}
+	});
+});


### PR DESCRIPTION
Adding the possibility to detect background-image urls on elements containing the hero image selector. 

Example:

```
<div class="hero-image" />

div {
   background: url('/image.png'); 
}
```


This should resolve #237. 