### PR TITLE
NPM: Allow running grunt build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,11 +2,9 @@
 .editorconfig
 .eslintignore
 .eslintrc
-Gruntfile.js
 jsdoc.conf.json
 doc-template/
 images/
-lib/
 tests/
 build/
 tasks/


### PR DESCRIPTION
We need to publish `Gruntfile.js` to NPM and make a few changes to allow for files not published to NPM (e.g. the `tests/**` directory).

Addresses https://github.com/akamai/boomerang/issues/260