### PR TITLE
Fix setting rt.si to UUID to fix the refreshing bug

### DIFF
--- a/boomerang.js
+++ b/boomerang.js
@@ -1113,7 +1113,7 @@ BOOMR_check_doc_domain();
 			 *
 			 * @memberof BOOMR.session
 			 */
-			ID: Math.random().toString(36).replace(/^0\./, ""),
+			ID: undefined,
 
 			/**
 			 * Session start time.
@@ -2382,6 +2382,10 @@ BOOMR_check_doc_domain();
 
 			if (typeof config.site_domain === "string") {
 				this.session.domain = config.site_domain;
+			}
+
+			if (BOOMR.session.enabled && typeof BOOMR.session.ID === "undefined") {
+				BOOMR.session.ID = BOOMR.utils.generateUUID();
 			}
 
 			// Set autorun if in config right now, as plugins that listen for page_ready

--- a/tests/page-templates/25-cookie/02-cookie-from-new-session.js
+++ b/tests/page-templates/25-cookie/02-cookie-from-new-session.js
@@ -20,6 +20,7 @@ describe("e2e/25-cookie/02-cookie-from-new-session", function() {
 		var cookie = BOOMR.utils.getSubCookies(BOOMR.utils.getCookie("RT"));
 
 		assert.isDefined(cookie.si);
+		assert.match(cookie.si, /-/);
 	});
 
 	it("Should have a Session Length (sl) of 1", function() {


### PR DESCRIPTION
**Description**

In this PR, I am fixing the following issue: https://github.com/akamai/boomerang/issues/273 

After this change `rt.si` will have a value of the form `UUID-(SessionStart in Base64)`. The `cookie.si` will only contain `UUID`. The reason for this is the cookie expires in 7 days whereas the session expires in 30 mins. Hence, for the session id: `UUID` will remain same for 7 days but a different session will identified by the `-(SessionStart in Base64)` suffix at the end.

The setting of `BOOMR.session.ID` is done in `BOOMR.init()`
