### PR TITLE
UserTiming: Update usertiming-compression package to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4004,12 +4004,14 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -4072,7 +4074,8 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -4104,7 +4107,8 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -4274,6 +4278,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4360,12 +4365,14 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-db": "~1.27.0"
           }
@@ -4441,7 +4448,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -4645,6 +4653,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -12304,9 +12313,9 @@
       }
     },
     "usertiming-compression": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/usertiming-compression/-/usertiming-compression-0.1.8.tgz",
-      "integrity": "sha512-iVs6t2enmXTIiXQicUjGOSsEQoVGwL+WZSzpgLzHRI4pYEbZAadhXq7kvtmxfL1IozJwHB53+n8e8cnuCSkArA=="
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/usertiming-compression/-/usertiming-compression-0.1.9.tgz",
+      "integrity": "sha512-PZzhw9EpwaQInPH/9IZYXIrjqcwYma2RZi3QMpVY6Uwrl7wWgQsRKubwd/mNbvNIHnu1EsGAk+ByyftmpYhzgw=="
     },
     "util": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "credit-card-regex": "2.0.0",
     "error-stack-parser": "1.3.3",
     "jsurl": "0.1.3",
-    "usertiming-compression": "^0.1.8"
+    "usertiming-compression": "^0.1.9"
   },
   "devDependencies": {
     "async": "^0.9.2",


### PR DESCRIPTION
**Description**

In this PR, I am just updating the version of `usertiming-compression` library from `0.1.8` to `0.1.9`. As a bug was fixed which could potentially break boomerang as the conversion of user-timings would fail for some cases. (More info here: https://github.com/nicjansma/usertiming-compression.js/pull/8)