### PR TITLE
AutoXHR: Adding xhr.ru (response URL) beacon parameter for XHR and Fetch

### DIFF
--- a/plugins/auto-xhr.js
+++ b/plugins/auto-xhr.js
@@ -1874,6 +1874,10 @@
 				return promise.then(function(response) {
 					var i, res, ct, parseJson = false, parseXML = false;
 
+					if (response.redirected) {
+						resource.responseUrl = response.url;
+					}
+
 					if (response.status < 200 || response.status >= 400) {
 						// put the HTTP error code on the resource if it's not a success
 						resource.status = response.status;
@@ -2080,6 +2084,9 @@
 								// meaning the request wasn't aborted.  Aborted requests will fire the
 								// next handler.
 								if (req.readyState === 4 && req.status !== 0) {
+
+									resource.responseUrl = req.responseURL;
+
 									if (req.status < 200 || req.status >= 400) {
 										// put the HTTP error code on the resource if it's not a success
 										resource.status = req.status;
@@ -2119,11 +2126,14 @@
 								}
 								else if (req.readyState === 0 && typeof resource.timing.open === "number") {
 									// something called .abort() after the request was started
+									resource.responseUrl = req.responseURL;
 									resource.status = XHR_STATUS_ABORT;
 									impl.loadFinished(resource);
 								}
 							}
 							else {
+								resource.responseUrl = req.responseURL;
+
 								// load, timeout, error, abort
 								if (ename === "load") {
 									if (req.status !== 0 && (req.status < 200 || req.status >= 400)) {

--- a/plugins/auto-xhr.js
+++ b/plugins/auto-xhr.js
@@ -2085,7 +2085,9 @@
 								// next handler.
 								if (req.readyState === 4 && req.status !== 0) {
 
-									resource.responseUrl = req.responseURL;
+									if (req.responseURL !== resource.url) {
+										resource.responseUrl = req.responseURL;
+									}
 
 									if (req.status < 200 || req.status >= 400) {
 										// put the HTTP error code on the resource if it's not a success
@@ -2126,13 +2128,17 @@
 								}
 								else if (req.readyState === 0 && typeof resource.timing.open === "number") {
 									// something called .abort() after the request was started
-									resource.responseUrl = req.responseURL;
+									if (req.responseURL !== resource.url) {
+										resource.responseUrl = req.responseURL;
+									}
 									resource.status = XHR_STATUS_ABORT;
 									impl.loadFinished(resource);
 								}
 							}
 							else {
-								resource.responseUrl = req.responseURL;
+								if (req.responseURL !== resource.url) {
+									resource.responseUrl = req.responseURL;
+								}
 
 								// load, timeout, error, abort
 								if (ename === "load") {

--- a/plugins/rt.js
+++ b/plugins/rt.js
@@ -70,7 +70,7 @@
  * * `fetch.bnu`: For XHR beacons from fetch API requests, `1` if fetch response body was not used.
  * * `rt.tt`: Sum of load times across session
  * * `rt.obo`: Number of pages in session that did not have a load time
- * * `ru`: final response URL after any redirects
+ * * `xhr.ru`: final response URL after any redirects
  *    - `XMLHttpRequest`: it will be present if any redirects happened
  *       and final URL is not equivalent to the final response URL after any redirects.
  *    - `fetch`: it will only be present if any redirects happened

--- a/plugins/rt.js
+++ b/plugins/rt.js
@@ -71,8 +71,8 @@
  * * `rt.tt`: Sum of load times across session
  * * `rt.obo`: Number of pages in session that did not have a load time
  * * `ru`: final response URL after any redirects
- *    - `XMLHttpRequest`: it will be present, even if no redirect happened.
- *       Since, we do not have a way to identify it
+ *    - `XMLHttpRequest`: it will be present if any redirects happened
+ *       and final URL is not equivalent to the final response URL after any redirects.
  *    - `fetch`: it will only be present if any redirects happened
  *
  * ## Cookie
@@ -1578,7 +1578,7 @@
 				}
 
 				if (edata.responseUrl) {
-					BOOMR.addVar("ru", edata.responseUrl, true);
+					BOOMR.addVar("xhr.ru", BOOMR.utils.cleanupURL(edata.responseUrl), true);
 				}
 			}
 

--- a/plugins/rt.js
+++ b/plugins/rt.js
@@ -70,6 +70,10 @@
  * * `fetch.bnu`: For XHR beacons from fetch API requests, `1` if fetch response body was not used.
  * * `rt.tt`: Sum of load times across session
  * * `rt.obo`: Number of pages in session that did not have a load time
+ * * `ru`: final response URL after any redirects
+ *    - `XMLHttpRequest`: it will be present, even if no redirect happened.
+ *       Since, we do not have a way to identify it
+ *    - `fetch`: it will only be present if any redirects happened
  *
  * ## Cookie
  *
@@ -1571,6 +1575,10 @@
 
 				if (edata.responseBodyNotUsed) {
 					BOOMR.addVar("fetch.bnu", 1, true);
+				}
+
+				if (edata.responseUrl) {
+					BOOMR.addVar("ru", edata.responseUrl, true);
 				}
 			}
 

--- a/tests/page-templates/07-autoxhr/52-xhr-response-url.html
+++ b/tests/page-templates/07-autoxhr/52-xhr-response-url.html
@@ -1,0 +1,42 @@
+<%= header %>
+<!--
+IE9 (and older) and phantomjs do not fire 'loadend' for XHRs, no autoxhr beacon was being sent
+-->
+<script src="52-xhr-response-url.js" type="text/javascript"></script>
+<%= boomerangScript %>
+<script>
+	var numBeacons = 1;
+	numBeacons += BOOMR.plugins.AutoXHR ? 2 : 0;
+	numBeacons += BOOMR_test.isFetchApiSupported() ? 2 : 0;
+	BOOMR_test.init({
+		testAfterOnBeacon: numBeacons,
+		instrument_xhr: true,
+		autorun: true,
+		AutoXHR: {
+			monitorFetch: true,
+			alwaysSendXhr: true
+		},
+		afterFirstBeacon:
+			function () {
+				if (!BOOMR.plugins.AutoXHR) {
+					return;
+				}
+
+				var xhr1 = new XMLHttpRequest();
+				xhr1.open("GET", "/302?to=/blackhole/test");
+				xhr1.send(null);
+
+				var xhr2 = new XMLHttpRequest();
+				xhr2.open("GET", "/blackhole");
+				xhr2.send(null);
+
+				if (BOOMR_test.isFetchApiSupported()) {
+					fetch("/302?to=/blackhole/test")
+						.then(response => console.log(response));
+					fetch("/blackhole")
+						.then(response => console.log(response));
+				}
+			}
+	});
+</script>
+<%= footer %>

--- a/tests/page-templates/07-autoxhr/52-xhr-response-url.html
+++ b/tests/page-templates/07-autoxhr/52-xhr-response-url.html
@@ -1,15 +1,10 @@
 <%= header %>
-<!--
-IE9 (and older) and phantomjs do not fire 'loadend' for XHRs, no autoxhr beacon was being sent
--->
 <script src="52-xhr-response-url.js" type="text/javascript"></script>
 <%= boomerangScript %>
 <script>
-	var numBeacons = 1;
-	numBeacons += BOOMR.plugins.AutoXHR ? 2 : 0;
-	numBeacons += BOOMR_test.isFetchApiSupported() ? 2 : 0;
+	var t = BOOMR_test;
 	BOOMR_test.init({
-		testAfterOnBeacon: numBeacons,
+		testAfterOnBeacon: BOOMR.plugins.AutoXHR ? (t.isFetchApiSupported() ? 5 : 3) : 1,
 		instrument_xhr: true,
 		autorun: true,
 		AutoXHR: {
@@ -17,25 +12,44 @@ IE9 (and older) and phantomjs do not fire 'loadend' for XHRs, no autoxhr beacon 
 			alwaysSendXhr: true
 		},
 		afterFirstBeacon:
-			function () {
+			function() {
 				if (!BOOMR.plugins.AutoXHR) {
 					return;
 				}
 
-				var xhr1 = new XMLHttpRequest();
-				xhr1.open("GET", "/302?to=/blackhole/test");
-				xhr1.send(null);
+				var num = 0;
+				var arr = [
+					function() {
+						var xhr = new XMLHttpRequest();
+						xhr.open("GET", "/302?to=/blackhole/test");
+						xhr.send(null);
+					},
+					function() {
+						var xhr = new XMLHttpRequest();
+						xhr.open("GET", "/blackhole");
+						xhr.send(null);
+					}
+				];
 
-				var xhr2 = new XMLHttpRequest();
-				xhr2.open("GET", "/blackhole");
-				xhr2.send(null);
-
-				if (BOOMR_test.isFetchApiSupported()) {
-					fetch("/302?to=/blackhole/test")
-						.then(response => console.log(response));
-					fetch("/blackhole")
-						.then(response => console.log(response));
+				if (t.isFetchApiSupported()) {
+					arr.push(function() {
+						fetch("/302?to=/blackhole/test");
+					});
+					arr.push(function() {
+						fetch("/blackhole");
+					});
 				}
+
+				function sendBeacon() {
+					if (num < arr.length) {
+						arr[num]();
+						num++;
+					}
+				}
+
+				BOOMR.subscribe("beacon", sendBeacon);
+
+				sendBeacon();
 			}
 	});
 </script>

--- a/tests/page-templates/07-autoxhr/52-xhr-response-url.js
+++ b/tests/page-templates/07-autoxhr/52-xhr-response-url.js
@@ -1,33 +1,80 @@
 /*eslint-env mocha*/
 /*global assert*/
 
-describe("e2e/07-autoxhr/52-xhr-response-url", function () {
+describe("e2e/07-autoxhr/52-xhr-response-url", function() {
     var t = BOOMR_test;
     var tf = BOOMR.plugins.TestFramework;
 
-    it("Should have sent beacons for each XHR/Fetch call", function (done) {
-        var n = BOOMR.plugins.AutoXHR ? (t.isFetchApiSupported() ? 5 : 3) : 1;
+    it("Should have sent beacons for each XHR/Fetch call", function(done) {
         t.ifAutoXHR(
             done,
-            function () {
-                t.ensureBeaconCount(done, n);
+            function() {
+                t.ensureBeaconCount(done, t.isFetchApiSupported() ? 5 : 3);
             },
             this.skip.bind(this)
         );
     });
 
-    it("Beacon parameter 'ru' should be present when redirection happened", function (done) {
+    it("For XHR, beacon parameter 'xhr.ru' should be present, since redirect happened and final url is not equal to the source url", function(done) {
         t.ifAutoXHR(
             done,
-            function () {
-                tf.beacons.filter(function (beacon) {
-                    return beacon["u"].indexOf("/302?to=/blackhole/test") >= 0;
-                }).forEach(beacon => {
-                    assert.strictEqual(beacon["ru"], "http://boomerang-test.local:4002/blackhole/test");
-                });
+            function() {
+                var beacon = tf.beacons[1];
+                assert.equal(beacon["http.initiator"], "xhr");
+                assert.include(beacon["u"], "/302?to=/blackhole/test");
+                assert.include(beacon["xhr.ru"], "/blackhole/test")
                 done();
             },
             this.skip.bind(this)
         );
     });
+
+    it("For XHR, beacon parameter 'xhr.ru' should NOT be present, since there was no redirect", function(done) {
+        t.ifAutoXHR(
+            done,
+            function() {
+                var beacon = tf.beacons[2];
+                assert.equal(beacon["http.initiator"], "xhr");
+                assert.include(beacon["u"], "/blackhole");
+                assert.isUndefined(beacon["xhr.ru"]);
+                done();
+            },
+            this.skip.bind(this)
+        );
+    });
+
+    it("For Fetch, beacon parameter 'xhr.ru' should be present, since redirect happened", function(done) {
+        if (!t.isFetchApiSupported()) {
+            return this.skip();
+        }
+        t.ifAutoXHR(
+            done,
+            function() {
+                var beacon = tf.beacons[3];
+                assert.equal(beacon["http.initiator"], "xhr");
+                assert.include(beacon["u"], "/302?to=/blackhole/test");
+                assert.include(beacon["xhr.ru"], "/blackhole/test")
+                done();
+            },
+            this.skip.bind(this)
+        );
+    });
+
+    it("For Fetch, beacon parameter 'xhr.ru' should NOT be present, since there was no redirect", function(done) {
+        if (!t.isFetchApiSupported()) {
+            return this.skip();
+        }
+        t.ifAutoXHR(
+            done,
+            function() {
+                var beacon = tf.beacons[4];
+                assert.equal(beacon["http.initiator"], "xhr");
+                assert.include(beacon["u"], "/blackhole");
+                assert.isUndefined(beacon["xhr.ru"]);
+                done();
+            },
+            this.skip.bind(this)
+        );
+    });
+
 });

--- a/tests/page-templates/07-autoxhr/52-xhr-response-url.js
+++ b/tests/page-templates/07-autoxhr/52-xhr-response-url.js
@@ -2,79 +2,79 @@
 /*global assert*/
 
 describe("e2e/07-autoxhr/52-xhr-response-url", function() {
-    var t = BOOMR_test;
-    var tf = BOOMR.plugins.TestFramework;
+	var t = BOOMR_test;
+	var tf = BOOMR.plugins.TestFramework;
 
-    it("Should have sent beacons for each XHR/Fetch call", function(done) {
-        t.ifAutoXHR(
-            done,
-            function() {
-                t.ensureBeaconCount(done, t.isFetchApiSupported() ? 5 : 3);
-            },
-            this.skip.bind(this)
-        );
-    });
+	it("Should have sent beacons for each XHR/Fetch call", function(done) {
+		t.ifAutoXHR(
+			done,
+			function() {
+				t.ensureBeaconCount(done, t.isFetchApiSupported() ? 5 : 3);
+			},
+			this.skip.bind(this)
+		);
+	});
 
-    it("For XHR, beacon parameter 'xhr.ru' should be present, since redirect happened and final url is not equal to the source url", function(done) {
-        t.ifAutoXHR(
-            done,
-            function() {
-                var beacon = tf.beacons[1];
-                assert.equal(beacon["http.initiator"], "xhr");
-                assert.include(beacon["u"], "/302?to=/blackhole/test");
-                assert.include(beacon["xhr.ru"], "/blackhole/test")
-                done();
-            },
-            this.skip.bind(this)
-        );
-    });
+	it("For XHR, beacon parameter 'xhr.ru' should be present, since redirect happened and final url is not equal to the source url", function(done) {
+		t.ifAutoXHR(
+			done,
+			function() {
+				var beacon = tf.beacons[1];
+				assert.equal(beacon["http.initiator"], "xhr");
+				assert.include(beacon.u, "/302?to=/blackhole/test");
+				assert.include(beacon["xhr.ru"], "/blackhole/test");
+				done();
+			},
+			this.skip.bind(this)
+		);
+	});
 
-    it("For XHR, beacon parameter 'xhr.ru' should NOT be present, since there was no redirect", function(done) {
-        t.ifAutoXHR(
-            done,
-            function() {
-                var beacon = tf.beacons[2];
-                assert.equal(beacon["http.initiator"], "xhr");
-                assert.include(beacon["u"], "/blackhole");
-                assert.isUndefined(beacon["xhr.ru"]);
-                done();
-            },
-            this.skip.bind(this)
-        );
-    });
+	it("For XHR, beacon parameter 'xhr.ru' should NOT be present, since there was no redirect", function(done) {
+		t.ifAutoXHR(
+			done,
+			function() {
+				var beacon = tf.beacons[2];
+				assert.equal(beacon["http.initiator"], "xhr");
+				assert.include(beacon.u, "/blackhole");
+				assert.isUndefined(beacon["xhr.ru"]);
+				done();
+			},
+			this.skip.bind(this)
+		);
+	});
 
-    it("For Fetch, beacon parameter 'xhr.ru' should be present, since redirect happened", function(done) {
-        if (!t.isFetchApiSupported()) {
-            return this.skip();
-        }
-        t.ifAutoXHR(
-            done,
-            function() {
-                var beacon = tf.beacons[3];
-                assert.equal(beacon["http.initiator"], "xhr");
-                assert.include(beacon["u"], "/302?to=/blackhole/test");
-                assert.include(beacon["xhr.ru"], "/blackhole/test")
-                done();
-            },
-            this.skip.bind(this)
-        );
-    });
+	it("For Fetch, beacon parameter 'xhr.ru' should be present, since redirect happened", function(done) {
+		if (!t.isFetchApiSupported()) {
+			return this.skip();
+		}
+		t.ifAutoXHR(
+			done,
+			function() {
+				var beacon = tf.beacons[3];
+				assert.equal(beacon["http.initiator"], "xhr");
+				assert.include(beacon.u, "/302?to=/blackhole/test");
+				assert.include(beacon["xhr.ru"], "/blackhole/test");
+				done();
+			},
+			this.skip.bind(this)
+		);
+	});
 
-    it("For Fetch, beacon parameter 'xhr.ru' should NOT be present, since there was no redirect", function(done) {
-        if (!t.isFetchApiSupported()) {
-            return this.skip();
-        }
-        t.ifAutoXHR(
-            done,
-            function() {
-                var beacon = tf.beacons[4];
-                assert.equal(beacon["http.initiator"], "xhr");
-                assert.include(beacon["u"], "/blackhole");
-                assert.isUndefined(beacon["xhr.ru"]);
-                done();
-            },
-            this.skip.bind(this)
-        );
-    });
+	it("For Fetch, beacon parameter 'xhr.ru' should NOT be present, since there was no redirect", function(done) {
+		if (!t.isFetchApiSupported()) {
+			return this.skip();
+		}
+		t.ifAutoXHR(
+			done,
+			function() {
+				var beacon = tf.beacons[4];
+				assert.equal(beacon["http.initiator"], "xhr");
+				assert.include(beacon.u, "/blackhole");
+				assert.isUndefined(beacon["xhr.ru"]);
+				done();
+			},
+			this.skip.bind(this)
+		);
+	});
 
 });

--- a/tests/page-templates/07-autoxhr/52-xhr-response-url.js
+++ b/tests/page-templates/07-autoxhr/52-xhr-response-url.js
@@ -1,0 +1,33 @@
+/*eslint-env mocha*/
+/*global assert*/
+
+describe("e2e/07-autoxhr/52-xhr-response-url", function () {
+    var t = BOOMR_test;
+    var tf = BOOMR.plugins.TestFramework;
+
+    it("Should have sent beacons for each XHR/Fetch call", function (done) {
+        var n = BOOMR.plugins.AutoXHR ? (t.isFetchApiSupported() ? 5 : 3) : 1;
+        t.ifAutoXHR(
+            done,
+            function () {
+                t.ensureBeaconCount(done, n);
+            },
+            this.skip.bind(this)
+        );
+    });
+
+    it("Beacon parameter 'ru' should be present when redirection happened", function (done) {
+        t.ifAutoXHR(
+            done,
+            function () {
+                tf.beacons.filter(function (beacon) {
+                    return beacon["u"].indexOf("/302?to=/blackhole/test") >= 0;
+                }).forEach(beacon => {
+                    assert.strictEqual(beacon["ru"], "http://boomerang-test.local:4002/blackhole/test");
+                });
+                done();
+            },
+            this.skip.bind(this)
+        );
+    });
+});

--- a/tests/server/app.js
+++ b/tests/server/app.js
@@ -53,6 +53,12 @@ function respond301(req, res) {
 	res.redirect(301, file);
 }
 
+function respond302(req, res) {
+	var q = require("url").parse(req.url, true).query;
+	var to = q.to || "/blackhole";
+	res.redirect(to);
+}
+
 function respond500(req, res) {
 	res.status(500).send();
 }
@@ -86,6 +92,9 @@ app.post("/delay", require("./route-delay"));
 // /redirect - 301 redirects
 app.get("/redirect", respond301);
 app.post("/redirect", respond301);
+
+// /redirect - 302
+app.get("/302", respond302);
 
 // /500 - Internal Server Error
 app.get("/500", respond500);
@@ -125,7 +134,7 @@ app.get("/*", function(req, res, next) {
 	});
 	input.on("open", function() {
 		var headers = {};
-		var lineReader = readline.createInterface({input: input});
+		var lineReader = readline.createInterface({ input: input });
 		lineReader.on("line", function(line) {
 			var colon = ":";
 			var colonIndex = line.indexOf(colon);


### PR DESCRIPTION
Adding new `ru` beacon parameter which contains the Response Url when XHR request is made.

- `XMLHttpRequest`: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseURL
- `fetch`: https://developer.mozilla.org/en-US/docs/Web/API/Response/url