### PR TITLE
Fix: Continuity high TTI values reported (mostly when c.tti gets leaked to other type of beacon)

### DIFF
--- a/plugins/continuity.js
+++ b/plugins/continuity.js
@@ -1198,7 +1198,7 @@
 
 		var idleIntervals = 0;
 
-		var bucketsVisited = undefined;
+		var bucketsVisited;
 
 		// check for pre-Boomerang FPS log
 		if (BOOMR.fpsLog && BOOMR.fpsLog.length) {
@@ -1749,7 +1749,8 @@
 				if (data.hasOwnProperty(type)) {
 					if (tti > 0) {
 						data[type] = [];
-					} else {
+					}
+					else {
 						var oldData = data[type];
 						var newData = new Array(bucketsVisited + 1);
 						data[type] = newData.concat(oldData.slice(bucketsVisited + 1));

--- a/plugins/continuity.js
+++ b/plugins/continuity.js
@@ -1623,9 +1623,12 @@
 			}
 
 			// determine the first bucket we'd use
-			var startBucket = bucketsVisited;
-			if (typeof startBucket === "undefined") {
+			var startBucket;
+			if (typeof bucketsVisited === "undefined") {
 				startBucket = Math.floor((visuallyReady - startTime) / COLLECTION_INTERVAL);
+			}
+			else {
+				startBucket = bucketsVisited + 1;
 			}
 
 			for (j = startBucket; j <= endBucket; j++) {
@@ -1747,13 +1750,13 @@
 			// clear the buckets
 			for (var type in data) {
 				if (data.hasOwnProperty(type)) {
-					if (tti > 0) {
-						data[type] = [];
-					}
-					else {
+					if (!tti && bucketsVisited > 0) {
 						var oldData = data[type];
 						var newData = new Array(bucketsVisited + 1);
 						data[type] = newData.concat(oldData.slice(bucketsVisited + 1));
+					}
+					else {
+						data[type] = [];
 					}
 				}
 			}


### PR DESCRIPTION
Hi Team,

Related partially on: https://github.com/akamai/boomerang/issues/248 https://github.com/akamai/boomerang/issues/245

### What we want
We want `c.tti` to be calculated accurately on the page load beacon (spa_hard or undefined initiators).

### Cases it fails:
**Unpredictable cases:**
- Page is hidden
- User has too many apps open (browser itself doesn't get much CPU) etc.

**Predictable cases:**
According to our code, the assumption of the value of `c.tti` is:

`VisuallyReady` < `c.tti`  < (`page_ready` + `waitAfterOnLoad`)

We try to calculate `c.tti` after `page_ready` is fired and for `waitAfterOnLoad` ms. After which we send page load beacon without `c.tti`. (Since our assumption equation didn't work for some users)

Now, If `afterOnLoad=true`

`c.tti` is possible to be attached to any type of beacon, especially when it fails at `page_load`. But then the `c.tti` values reported are very high and very unreliable. I know it's anyways not a good idea to trust them. But this PR tries to somewhat rectify that issue.

### Scenario

- User goes to a page
- `c.tti` failed to be calculated
- Page load beacon is sent without `c.tti`
- ** Data in the `Timeline` class in Continuity flushes its data.
- User scrolls up and down on the page. A number of beacon starts getting sent (error, xhr, interactions, clicks etc.)
- **`c.tti` is calculated before every beacon being sent (but never has good enough data (for seeing 500ms CPU idle) because the real data gets flushed whenever a beacon is sent)**
- User then starts doing something else (anything apart from interacting with the page like playing COD mobile)
- User comes back to the page after he wins a battle royale.
- Another beacon is sent (this time we have quite a lot of data to find the 500 ms CPU).
```
if (data.fps && (!data.fps[j] || data.fps[j] < TIME_TO_INTERACTIVE_MIN_FPS_PER_INTERVAL)) {
    // No FPS or less than 20 FPS during this interval
    idleIntervals = 0;
    continue;
}
```
- Because we flushed data every time. This condition `!data.fps[j]` makes the function feel that the page was busy until the time we last started capturing the data. (which is when the User went to play COD mobile)
- Hence `c.tti` will be reported as the last time we started capturing the data. (and it will be a very large value, because of the time he spent scrolling up and down on the page)

### Fix

- Moving `idleIntervals` outside the loop. Because we want to remember the number of intervals it was free before flushing out the data.
- Adding `bucketsVisited` to track buckets we have already visited. So that we don't go through the data again for which we didn't see any improvements
- Making `onBeacon` to remove only the data that we have seen. But if `c.tti` was calculated then flush as we use to before.

