### PR TITLE
package.json: Fix install/postinstall to use non-global scripts and be platform independent

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,11 +83,13 @@
   },
   "scripts": {
     "test": "grunt test",
-    "install": "bower install && webdriver-manager update --versions.chrome=$(google-chrome --product-version)",
+    "postinstall": "npm run bower-install && npm run webdriver-manager-update",
     "build": "grunt clean build",
     "lint": "grunt lint",
     "unit-test": "grunt test:unit",
-    "e2e-test": "grunt test:e2e --webdriver-versions=\"--versions.chrome $(google-chrome --product-version)\""
+    "e2e-test": "grunt test:e2e --webdriver-versions=\"--versions.chrome $(google-chrome --product-version)\"",
+    "bower-install": "./node_modules/.bin/bower install",
+    "webdriver-manager-update": "./node_modules/.bin/webdriver-manager update --versions.chrome=$(google-chrome --product-version)"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes https://github.com/akamai/boomerang/issues/313

* Changes from `install` to `postinstall`, so we can depend on the local installation.
* Splits commands into two NPM scripts: `bower-install` and `webdriver-manager-update`, so NPM can handle the relative paths 
`./node_modules/.bin/` OK (when combined with `&&` it wasn't working for the second command on Windows).