### PR TITLE
Reduce the file size of snippets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -736,7 +736,9 @@ function getConfig() {
 			snippets: {
 				options: {
 					preserveComments: false,
-					mangle: true,
+					mangle: {
+						reserved: ["w"]
+					},
 					banner: "",
 					// NOTE: Not compressing so things like our <bo + dy> optimization aren't removed
 					compress: false

--- a/snippets/continuity-snippet.js
+++ b/snippets/continuity-snippet.js
@@ -1,22 +1,22 @@
-(function() {
-	if (window && window.requestAnimationFrame) {
-		window.BOOMR = window.BOOMR || {};
-		window.BOOMR.fpsLog = [];
+(function(w) {
+	if (w && w.requestAnimationFrame) {
+		w.BOOMR = w.BOOMR || {};
+		w.BOOMR.fpsLog = [];
 
 		function frame(now) {
-			// window.BOOMR.fpsLog will get deleted once Boomerang has loaded
-			if (window.BOOMR.fpsLog) {
-				window.BOOMR.fpsLog.push(Math.round(now));
+			// w.BOOMR.fpsLog will get deleted once Boomerang has loaded
+			if (w.BOOMR.fpsLog) {
+				w.BOOMR.fpsLog.push(Math.round(now));
 
 				// if we've added more than 30 seconds of data, stop
-				if (window.BOOMR.fpsLog.length > 30 * 60) {
+				if (w.BOOMR.fpsLog.length > 30 * 60) {
 					return;
 				}
 
-				window.requestAnimationFrame(frame);
+				w.requestAnimationFrame(frame);
 			}
 		}
 
-		window.requestAnimationFrame(frame);
+		w.requestAnimationFrame(frame);
 	}
-})();
+})(window);

--- a/snippets/loader-snippet-after-onload.js
+++ b/snippets/loader-snippet-after-onload.js
@@ -1,17 +1,17 @@
 /* eslint-disable no-script-url */
-(function() {
+(function(w) {
 	// Boomerang Loader Snippet version 14
-	if (window.BOOMR && (window.BOOMR.version || window.BOOMR.snippetExecuted)) {
+	if (w.BOOMR && (w.BOOMR.version || w.BOOMR.snippetExecuted)) {
 		return;
 	}
 
-	window.BOOMR = window.BOOMR || {};
-	window.BOOMR.snippetStart = new Date().getTime();
-	window.BOOMR.snippetExecuted = true;
-	window.BOOMR.snippetVersion = 14;
+	w.BOOMR = w.BOOMR || {};
+	w.BOOMR.snippetStart = new Date().getTime();
+	w.BOOMR.snippetExecuted = true;
+	w.BOOMR.snippetVersion = 14;
 
 	// NOTE: Set Boomerang URL here
-	window.BOOMR.url = "";
+	w.BOOMR.url = "";
 
 	var // document.currentScript is supported in all browsers other than IE
 	    where = document.currentScript || document.getElementsByTagName("script")[0],
@@ -30,7 +30,7 @@
 
 		var script = document.createElement("script");
 		script.id = "boomr-scr-as";
-		script.src = window.BOOMR.url;
+		script.src = w.BOOMR.url;
 
 		// Not really needed since dynamic scripts are async by default and the script is already in cache at this point,
 		// but some naive parsers will see a missing async attribute and think we're not async
@@ -46,15 +46,15 @@
 	function iframeLoader(wasFallback) {
 		promoted = true;
 
-		var dom, doc = document, bootstrap, iframe, iframeStyle, win = window;
+		var dom, doc = document, bootstrap, iframe, iframeStyle, win = w;
 
-		window.BOOMR.snippetMethod = wasFallback ? "if" : "i";
+		w.BOOMR.snippetMethod = wasFallback ? "if" : "i";
 
 		// Adds Boomerang within the iframe
 		bootstrap = function(parent, scriptId) {
 			var script = doc.createElement("script");
 			script.id = scriptId || "boomr-if-as";
-			script.src = window.BOOMR.url;
+			script.src = w.BOOMR.url;
 
 			BOOMR_lstart = new Date().getTime();
 
@@ -64,8 +64,8 @@
 
 		// For IE 6/7, we'll just load the script in the current frame, as those browsers don't support 'about:blank'
 		// for an iframe src (it triggers warnings on secure sites).  This means loading on IE 6/7 may cause SPoF.
-		if (!window.addEventListener && window.attachEvent && navigator.userAgent.match(/MSIE [67]\./)) {
-			window.BOOMR.snippetMethod = "s";
+		if (!w.addEventListener && w.attachEvent && navigator.userAgent.match(/MSIE [67]\./)) {
+			w.BOOMR.snippetMethod = "s";
 
 			bootstrap(parentNode, "boomr-async");
 			return;
@@ -152,10 +152,10 @@
 		    typeof link.relList.supports === "function" &&
 		    link.relList.supports("preload") &&
 		    ("as" in link)) {
-			window.BOOMR.snippetMethod = "p";
+			w.BOOMR.snippetMethod = "p";
 
 			// Set attributes to trigger a Preload
-			link.href = window.BOOMR.url;
+			link.href = w.BOOMR.url;
 			link.rel  = "preload";
 			link.as   = "script";
 
@@ -186,14 +186,14 @@
 
 	// Save when the onload event happened, in case this is a non-NavigationTiming browser
 	function boomerangSaveLoadTime(e) {
-		window.BOOMR_onload = (e && e.timeStamp) || new Date().getTime();
+		w.BOOMR_onload = (e && e.timeStamp) || new Date().getTime();
 	}
 
-	if (window.addEventListener) {
-		window.addEventListener("load", boomerangSaveLoadTime, false);
+	if (w.addEventListener) {
+		w.addEventListener("load", boomerangSaveLoadTime, false);
 	}
-	else if (window.attachEvent) {
-		window.attachEvent("onload", boomerangSaveLoadTime);
+	else if (w.attachEvent) {
+		w.attachEvent("onload", boomerangSaveLoadTime);
 	}
 
 	// Run at onload
@@ -216,4 +216,4 @@
 			win.attachEvent("onload", windowOnLoad);
 		}
 	}
-})();
+})(window);

--- a/snippets/loader-snippet.js
+++ b/snippets/loader-snippet.js
@@ -1,17 +1,17 @@
 /* eslint-disable no-script-url */
-(function() {
+(function(w) {
 	// Boomerang Loader Snippet version 14
-	if (window.BOOMR && (window.BOOMR.version || window.BOOMR.snippetExecuted)) {
+	if (w.BOOMR && (w.BOOMR.version || w.BOOMR.snippetExecuted)) {
 		return;
 	}
 
-	window.BOOMR = window.BOOMR || {};
-	window.BOOMR.snippetStart = new Date().getTime();
-	window.BOOMR.snippetExecuted = true;
-	window.BOOMR.snippetVersion = 14;
+	w.BOOMR = w.BOOMR || {};
+	w.BOOMR.snippetStart = new Date().getTime();
+	w.BOOMR.snippetExecuted = true;
+	w.BOOMR.snippetVersion = 14;
 
 	// NOTE: Set Boomerang URL here
-	window.BOOMR.url = "";
+	w.BOOMR.url = "";
 
 	var // document.currentScript is supported in all browsers other than IE
 	    where = document.currentScript || document.getElementsByTagName("script")[0],
@@ -25,7 +25,7 @@
 	/* BEGIN_TEST_CODE */
 	var prefix, suffix;
 
-	if (window.BOOMR_script_delay) {
+	if (w.BOOMR_script_delay) {
 		prefix = "/delay?delay=3000&file=build/";
 		suffix = "&rnd=" + Math.random();
 	}
@@ -34,11 +34,11 @@
 		suffix = "";
 	}
 
-	if (/\/support\//.test(window.location.pathname)) {
+	if (/\/support\//.test(w.location.pathname)) {
 		prefix = prefix.replace("build/", "../build/");
 	}
 
-	window.BOOMR.url = prefix + (window.BOOMR_script_minified ? "boomerang-latest-debug.min.js" : "boomerang-latest-debug.js") + suffix;
+	w.BOOMR.url = prefix + (w.BOOMR_script_minified ? "boomerang-latest-debug.min.js" : "boomerang-latest-debug.js") + suffix;
 	/* END_TEST_CODE */
 	// Tells the browser to execute the Preloaded script by adding it to the DOM
 	function promote() {
@@ -48,7 +48,7 @@
 
 		var script = document.createElement("script");
 		script.id = "boomr-scr-as";
-		script.src = window.BOOMR.url;
+		script.src = w.BOOMR.url;
 
 		// Not really needed since dynamic scripts are async by default and the script is already in cache at this point,
 		// but some naive parsers will see a missing async attribute and think we're not async
@@ -64,15 +64,15 @@
 	function iframeLoader(wasFallback) {
 		promoted = true;
 
-		var dom, doc = document, bootstrap, iframe, iframeStyle, win = window;
+		var dom, doc = document, bootstrap, iframe, iframeStyle, win = w;
 
-		window.BOOMR.snippetMethod = wasFallback ? "if" : "i";
+		w.BOOMR.snippetMethod = wasFallback ? "if" : "i";
 
 		// Adds Boomerang within the iframe
 		bootstrap = function(parent, scriptId) {
 			var script = doc.createElement("script");
 			script.id = scriptId || "boomr-if-as";
-			script.src = window.BOOMR.url;
+			script.src = w.BOOMR.url;
 
 			BOOMR_lstart = new Date().getTime();
 
@@ -82,8 +82,8 @@
 
 		// For IE 6/7, we'll just load the script in the current frame, as those browsers don't support 'about:blank'
 		// for an iframe src (it triggers warnings on secure sites).  This means loading on IE 6/7 may cause SPoF.
-		if (!window.addEventListener && window.attachEvent && navigator.userAgent.match(/MSIE [67]\./)) {
-			window.BOOMR.snippetMethod = "s";
+		if (!w.addEventListener && w.attachEvent && navigator.userAgent.match(/MSIE [67]\./)) {
+			w.BOOMR.snippetMethod = "s";
 
 			bootstrap(parentNode, "boomr-async");
 			return;
@@ -169,10 +169,10 @@
 	    typeof link.relList.supports === "function" &&
 	    link.relList.supports("preload") &&
 	    ("as" in link)) {
-		window.BOOMR.snippetMethod = "p";
+		w.BOOMR.snippetMethod = "p";
 
 		// Set attributes to trigger a Preload
-		link.href = window.BOOMR.url;
+		link.href = w.BOOMR.url;
 		link.rel  = "preload";
 		link.as   = "script";
 
@@ -202,13 +202,13 @@
 
 	// Save when the onload event happened, in case this is a non-NavigationTiming browser
 	function boomerangSaveLoadTime(e) {
-		window.BOOMR_onload = (e && e.timeStamp) || new Date().getTime();
+		w.BOOMR_onload = (e && e.timeStamp) || new Date().getTime();
 	}
 
-	if (window.addEventListener) {
-		window.addEventListener("load", boomerangSaveLoadTime, false);
+	if (w.addEventListener) {
+		w.addEventListener("load", boomerangSaveLoadTime, false);
 	}
-	else if (window.attachEvent) {
-		window.attachEvent("onload", boomerangSaveLoadTime);
+	else if (w.attachEvent) {
+		w.attachEvent("onload", boomerangSaveLoadTime);
 	}
-})();
+})(window);

--- a/tests/page-template-snippets/boomerangAfterOnloadSnippetNoScript.tpl
+++ b/tests/page-template-snippets/boomerangAfterOnloadSnippetNoScript.tpl
@@ -1,17 +1,17 @@
 /* eslint-disable no-script-url */
-(function() {
+(function(w) {
 	// Boomerang Loader Snippet version 14
-	if (window.BOOMR && (window.BOOMR.version || window.BOOMR.snippetExecuted)) {
+	if (w.BOOMR && (w.BOOMR.version || w.BOOMR.snippetExecuted)) {
 		return;
 	}
 
-	window.BOOMR = window.BOOMR || {};
-	window.BOOMR.snippetStart = new Date().getTime();
-	window.BOOMR.snippetExecuted = true;
-	window.BOOMR.snippetVersion = 14;
+	w.BOOMR = w.BOOMR || {};
+	w.BOOMR.snippetStart = new Date().getTime();
+	w.BOOMR.snippetExecuted = true;
+	w.BOOMR.snippetVersion = 14;
 
 	// NOTE: Set Boomerang URL here
-	window.BOOMR.url = "";
+	w.BOOMR.url = "";
 
 	var // document.currentScript is supported in all browsers other than IE
 	    where = document.currentScript || document.getElementsByTagName("script")[0],
@@ -30,7 +30,7 @@
 
 		var script = document.createElement("script");
 		script.id = "boomr-scr-as";
-		script.src = window.BOOMR.url;
+		script.src = w.BOOMR.url;
 
 		// Not really needed since dynamic scripts are async by default and the script is already in cache at this point,
 		// but some naive parsers will see a missing async attribute and think we're not async
@@ -46,15 +46,15 @@
 	function iframeLoader(wasFallback) {
 		promoted = true;
 
-		var dom, doc = document, bootstrap, iframe, iframeStyle, win = window;
+		var dom, doc = document, bootstrap, iframe, iframeStyle, win = w;
 
-		window.BOOMR.snippetMethod = wasFallback ? "if" : "i";
+		w.BOOMR.snippetMethod = wasFallback ? "if" : "i";
 
 		// Adds Boomerang within the iframe
 		bootstrap = function(parent, scriptId) {
 			var script = doc.createElement("script");
 			script.id = scriptId || "boomr-if-as";
-			script.src = window.BOOMR.url;
+			script.src = w.BOOMR.url;
 
 			BOOMR_lstart = new Date().getTime();
 
@@ -64,8 +64,8 @@
 
 		// For IE 6/7, we'll just load the script in the current frame, as those browsers don't support 'about:blank'
 		// for an iframe src (it triggers warnings on secure sites).  This means loading on IE 6/7 may cause SPoF.
-		if (!window.addEventListener && window.attachEvent && navigator.userAgent.match(/MSIE [67]\./)) {
-			window.BOOMR.snippetMethod = "s";
+		if (!w.addEventListener && w.attachEvent && navigator.userAgent.match(/MSIE [67]\./)) {
+			w.BOOMR.snippetMethod = "s";
 
 			bootstrap(parentNode, "boomr-async");
 			return;
@@ -152,10 +152,10 @@
 		    typeof link.relList.supports === "function" &&
 		    link.relList.supports("preload") &&
 		    ("as" in link)) {
-			window.BOOMR.snippetMethod = "p";
+			w.BOOMR.snippetMethod = "p";
 
 			// Set attributes to trigger a Preload
-			link.href = window.BOOMR.url;
+			link.href = w.BOOMR.url;
 			link.rel  = "preload";
 			link.as   = "script";
 
@@ -186,14 +186,14 @@
 
 	// Save when the onload event happened, in case this is a non-NavigationTiming browser
 	function boomerangSaveLoadTime(e) {
-		window.BOOMR_onload = (e && e.timeStamp) || new Date().getTime();
+		w.BOOMR_onload = (e && e.timeStamp) || new Date().getTime();
 	}
 
-	if (window.addEventListener) {
-		window.addEventListener("load", boomerangSaveLoadTime, false);
+	if (w.addEventListener) {
+		w.addEventListener("load", boomerangSaveLoadTime, false);
 	}
-	else if (window.attachEvent) {
-		window.attachEvent("onload", boomerangSaveLoadTime);
+	else if (w.attachEvent) {
+		w.attachEvent("onload", boomerangSaveLoadTime);
 	}
 
 	// Run at onload
@@ -216,4 +216,4 @@
 			win.attachEvent("onload", windowOnLoad);
 		}
 	}
-})();
+})(window);

--- a/tests/page-template-snippets/boomerangSnippetNoScript.tpl
+++ b/tests/page-template-snippets/boomerangSnippetNoScript.tpl
@@ -1,17 +1,17 @@
 /* eslint-disable no-script-url */
-(function() {
+(function(w) {
 	// Boomerang Loader Snippet version 14
-	if (window.BOOMR && (window.BOOMR.version || window.BOOMR.snippetExecuted)) {
+	if (w.BOOMR && (w.BOOMR.version || w.BOOMR.snippetExecuted)) {
 		return;
 	}
 
-	window.BOOMR = window.BOOMR || {};
-	window.BOOMR.snippetStart = new Date().getTime();
-	window.BOOMR.snippetExecuted = true;
-	window.BOOMR.snippetVersion = 14;
+	w.BOOMR = w.BOOMR || {};
+	w.BOOMR.snippetStart = new Date().getTime();
+	w.BOOMR.snippetExecuted = true;
+	w.BOOMR.snippetVersion = 14;
 
 	// NOTE: Set Boomerang URL here
-	window.BOOMR.url = "";
+	w.BOOMR.url = "";
 
 	var // document.currentScript is supported in all browsers other than IE
 	    where = document.currentScript || document.getElementsByTagName("script")[0],
@@ -25,7 +25,7 @@
 	/* BEGIN_TEST_CODE */
 	var prefix, suffix;
 
-	if (window.BOOMR_script_delay) {
+	if (w.BOOMR_script_delay) {
 		prefix = "/delay?delay=3000&file=build/";
 		suffix = "&rnd=" + Math.random();
 	}
@@ -34,11 +34,11 @@
 		suffix = "";
 	}
 
-	if (/\/support\//.test(window.location.pathname)) {
+	if (/\/support\//.test(w.location.pathname)) {
 		prefix = prefix.replace("build/", "../build/");
 	}
 
-	window.BOOMR.url = prefix + (window.BOOMR_script_minified ? "boomerang-latest-debug.min.js" : "boomerang-latest-debug.js") + suffix;
+	w.BOOMR.url = prefix + (w.BOOMR_script_minified ? "boomerang-latest-debug.min.js" : "boomerang-latest-debug.js") + suffix;
 	/* END_TEST_CODE */
 	// Tells the browser to execute the Preloaded script by adding it to the DOM
 	function promote() {
@@ -48,7 +48,7 @@
 
 		var script = document.createElement("script");
 		script.id = "boomr-scr-as";
-		script.src = window.BOOMR.url;
+		script.src = w.BOOMR.url;
 
 		// Not really needed since dynamic scripts are async by default and the script is already in cache at this point,
 		// but some naive parsers will see a missing async attribute and think we're not async
@@ -64,15 +64,15 @@
 	function iframeLoader(wasFallback) {
 		promoted = true;
 
-		var dom, doc = document, bootstrap, iframe, iframeStyle, win = window;
+		var dom, doc = document, bootstrap, iframe, iframeStyle, win = w;
 
-		window.BOOMR.snippetMethod = wasFallback ? "if" : "i";
+		w.BOOMR.snippetMethod = wasFallback ? "if" : "i";
 
 		// Adds Boomerang within the iframe
 		bootstrap = function(parent, scriptId) {
 			var script = doc.createElement("script");
 			script.id = scriptId || "boomr-if-as";
-			script.src = window.BOOMR.url;
+			script.src = w.BOOMR.url;
 
 			BOOMR_lstart = new Date().getTime();
 
@@ -82,8 +82,8 @@
 
 		// For IE 6/7, we'll just load the script in the current frame, as those browsers don't support 'about:blank'
 		// for an iframe src (it triggers warnings on secure sites).  This means loading on IE 6/7 may cause SPoF.
-		if (!window.addEventListener && window.attachEvent && navigator.userAgent.match(/MSIE [67]\./)) {
-			window.BOOMR.snippetMethod = "s";
+		if (!w.addEventListener && w.attachEvent && navigator.userAgent.match(/MSIE [67]\./)) {
+			w.BOOMR.snippetMethod = "s";
 
 			bootstrap(parentNode, "boomr-async");
 			return;
@@ -169,10 +169,10 @@
 	    typeof link.relList.supports === "function" &&
 	    link.relList.supports("preload") &&
 	    ("as" in link)) {
-		window.BOOMR.snippetMethod = "p";
+		w.BOOMR.snippetMethod = "p";
 
 		// Set attributes to trigger a Preload
-		link.href = window.BOOMR.url;
+		link.href = w.BOOMR.url;
 		link.rel  = "preload";
 		link.as   = "script";
 
@@ -202,13 +202,13 @@
 
 	// Save when the onload event happened, in case this is a non-NavigationTiming browser
 	function boomerangSaveLoadTime(e) {
-		window.BOOMR_onload = (e && e.timeStamp) || new Date().getTime();
+		w.BOOMR_onload = (e && e.timeStamp) || new Date().getTime();
 	}
 
-	if (window.addEventListener) {
-		window.addEventListener("load", boomerangSaveLoadTime, false);
+	if (w.addEventListener) {
+		w.addEventListener("load", boomerangSaveLoadTime, false);
 	}
-	else if (window.attachEvent) {
-		window.attachEvent("onload", boomerangSaveLoadTime);
+	else if (w.attachEvent) {
+		w.attachEvent("onload", boomerangSaveLoadTime);
 	}
-})();
+})(window);

--- a/tests/page-template-snippets/continuitySnippetNoScript.tpl
+++ b/tests/page-template-snippets/continuitySnippetNoScript.tpl
@@ -1,22 +1,22 @@
-(function() {
-	if (window && window.requestAnimationFrame) {
-		window.BOOMR = window.BOOMR || {};
-		window.BOOMR.fpsLog = [];
+(function(w) {
+	if (w && w.requestAnimationFrame) {
+		w.BOOMR = w.BOOMR || {};
+		w.BOOMR.fpsLog = [];
 
 		function frame(now) {
-			// window.BOOMR.fpsLog will get deleted once Boomerang has loaded
-			if (window.BOOMR.fpsLog) {
-				window.BOOMR.fpsLog.push(Math.round(now));
+			// w.BOOMR.fpsLog will get deleted once Boomerang has loaded
+			if (w.BOOMR.fpsLog) {
+				w.BOOMR.fpsLog.push(Math.round(now));
 
 				// if we've added more than 30 seconds of data, stop
-				if (window.BOOMR.fpsLog.length > 30 * 60) {
+				if (w.BOOMR.fpsLog.length > 30 * 60) {
 					return;
 				}
 
-				window.requestAnimationFrame(frame);
+				w.requestAnimationFrame(frame);
 			}
 		}
 
-		window.requestAnimationFrame(frame);
+		w.requestAnimationFrame(frame);
 	}
-})();
+})(window);


### PR DESCRIPTION
Before:
```
build/snippets/continuity-snippet.min.js: Size of 298 bytes (0.29 kilobyte)
build/snippets/loader-snippet-after-onload.min.js: Size of 2,445 bytes (2.39 kilobyte)
build/snippets/loader-snippet.min.js: Size of 2,133 bytes (2.08 kilobyte)
```

After:
```
build/snippets/continuity-snippet.min.js: Size of 255 bytes (0.25 kilobyte)
build/snippets/loader-snippet-after-onload.min.js: Size of 2,337 bytes (2.28 kilobyte)
build/snippets/loader-snippet.min.js: Size of 2,025 bytes (1.98 kilobyte)
```