### PR TITLE
Add support for SVGAnimatedString

### DIFF
--- a/plugins/auto-xhr.js
+++ b/plugins/auto-xhr.js
@@ -1352,6 +1352,7 @@
 			// but does not return a string
 			url = node.src ||
 				(typeof node.getAttribute === "function" && node.getAttribute("xlink:href")) ||
+				(node.href instanceof SVGAnimatedString && node.href.baseVal) ||
 				node.href;
 
 			// we get called from src/href attribute changes but also from nodes being added


### PR DESCRIPTION
```js
Uncaught TypeError: e.match is not a function
```

![SVGAnimatedString](https://user-images.githubusercontent.com/2867188/151650996-0f736a65-fe6d-44c5-a8bb-5e6bf35fc239.png)
