### PR TITLE
SPA: Lint: Fix incorrectly globally exported variable

### DIFF
--- a/plugins/spa.js
+++ b/plugins/spa.js
@@ -597,7 +597,7 @@
 		 * @returns {boolean} true if one of the SPA frameworks is enabled
 		 */
 		isSinglePageApp: function(config) {
-			var singlePageApp = false, frameworks = this.supported_frameworks();
+			var singlePageApp = false, frameworks = this.supported_frameworks(), i;
 			for (i = 0; i < frameworks.length; i++) {
 				var spa = frameworks[i];
 				if (config[spa] && config[spa].enabled) {


### PR DESCRIPTION
Make sure loop variable `i` is declared before using it so it doesn't become a global.

Closes #342
