### PR TITLE
Bandwidth plugin listen for xhr_load on SPA

### DIFF
--- a/plugins/bw.js
+++ b/plugins/bw.js
@@ -734,6 +734,7 @@
 
       if (!impl.setVarsFromCookie()) {
         BOOMR.subscribe("page_ready", this.run, null, this);
+        BOOMR.subscribe("xhr_load", this.run, null, this);
       }
 
       impl.initialized = true;

--- a/tests/page-templates/32-autoxhr-spa/22-bandwidth-spa.html
+++ b/tests/page-templates/32-autoxhr-spa/22-bandwidth-spa.html
@@ -1,0 +1,26 @@
+<%= header %>
+<%= boomerangSnippet %>
+<button id="navigate">Navigate to New State</button>
+<script src="22-bandwidth-spa.js" type="text/javascript"></script>
+<script>
+BOOMR_test.init({
+  testAfterOnBeacon: true,
+  BW: {
+    base_url: window.location.protocol +  "//" + window.location.hostname + ":" + window.location.port + "/pages/34-bw/support/images/",
+    block_beacon: true
+  },
+  user_ip: "abc123",
+  History: {
+    enabled: true,  // wait for soft navs
+    auto: true
+  },
+  afterFirstBeacon: function() {
+    document.getElementById("navigate").addEventListener("click", function() {
+      // Simulate a route change
+      BOOMR_test.routeChangeRnd("newstate");
+    });
+  },
+  autorun: false  // wait for soft navs
+});
+</script>
+<%= footer %>

--- a/tests/page-templates/32-autoxhr-spa/22-bandwidth-spa.js
+++ b/tests/page-templates/32-autoxhr-spa/22-bandwidth-spa.js
@@ -1,0 +1,23 @@
+/* eslint-env mocha */
+/* global BOOMR_test,assert */
+
+describe("e2e/32-autoxhr-spa/22-brandwidth-spa.js", function() {
+  var t = BOOMR_test;
+
+  var tf = BOOMR.plugins.TestFramework;
+
+  it("Should return bandwidth in beacon", function() {
+    if (!t.isNetworkAPISupported()) {
+      return;
+    }
+
+    var b = tf.beacons[0];
+
+    assert(b.bw_time);
+    assert(b.bw_time > 0);
+    assert(!isNaN(b.bw_err));
+    assert(b.bw_err > 0);
+    assert(!isNaN(b.bw));
+    assert(b.bw > 0);
+  });
+});


### PR DESCRIPTION
So that the Bandwidth plugin runs on single page apps,
modify Bandwidth Plugin to trigger on "xhr_load" events.

SOADEVESC-1830